### PR TITLE
Add JetBrains IDE project settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ buildNumber.properties
 .project
 .classpath
 
+# JetBrains IDE settings
+.idea/
+
 # Compiled class file
 *.class
 


### PR DESCRIPTION
Add the `.idea` project settings directory to `.gitignore` to make it easier for JetBrains IDE users to start making clean commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to ignore JetBrains IDE settings folder `.idea/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->