### PR TITLE
Katacombs starter improvements

### DIFF
--- a/18-katacombs/pom.xml
+++ b/18-katacombs/pom.xml
@@ -56,7 +56,14 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
                 <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <id>report</id>
                         <phase>test</phase>

--- a/18-katacombs/pom.xml
+++ b/18-katacombs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.4.1</version>
         <relativePath/>
     </parent>
 

--- a/18-katacombs/pom.xml
+++ b/18-katacombs/pom.xml
@@ -45,16 +45,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/18-katacombs/pom.xml
+++ b/18-katacombs/pom.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.2.3</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <groupId>com.github.pedromsantos</groupId>
@@ -83,5 +82,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/18-katacombs/pom.xml
+++ b/18-katacombs/pom.xml
@@ -54,10 +54,6 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>

--- a/18-katacombs/src/test/java/com/github/pedromsantos/KatacombsApplicationTests.java
+++ b/18-katacombs/src/test/java/com/github/pedromsantos/KatacombsApplicationTests.java
@@ -1,0 +1,13 @@
+package com.github.pedromsantos;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class KatacombsApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/18-katacombs/src/test/java/com/github/pedromsantos/KatacombsApplicationTests.java
+++ b/18-katacombs/src/test/java/com/github/pedromsantos/KatacombsApplicationTests.java
@@ -8,6 +8,7 @@ class KatacombsApplicationTests {
 
 	@Test
 	void contextLoads() {
+		// Verifies that the application context loads without errors, ensuring the basic configuration is correct.
 	}
 
 }


### PR DESCRIPTION
Some version bumps, corrections and tidyings to the recent addition of starter code for Katacombs.

- Runs [Tidy Maven Plugin](https://www.mojohaus.org/tidy-maven-plugin/) against Katacombs POM and reformats with default IntelliJ style
- Bumps Spring Boot to latest version
- Removes redundant dependency declarations, since `spring-boot-starter-test` already includes JUnit and AssertJ
- Removes redundant Maven Surefire Plugin declaration since this is inherited from the Maven Super POM
- Corrects JaCoCo configuration in the Katacombs POM since the plugin version and `prepare-agent` execution are no longer inherited from the repository root POM
- Adds the default `@SpringBootTest`-annotated test that is always generated by [Spring Initializr](https://start.spring.io/) as a startingpoint and to verify that the starting code results in a functioning Spring Context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Updated Spring Boot parent version to 3.4.1
	- Updated Jacoco Maven Plugin to version 0.8.12

- **Testing**
	- Removed JUnit Jupiter and AssertJ Core dependencies
	- Removed Maven Surefire Plugin
	- Added basic application context loading test

- **Configuration**
	- Updated Maven XML schema to use secure HTTPS connection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->