### PR TITLE
Upgrade to java 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,7 +2,6 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
 

--- a/1-fizzbuzz/pom.xml
+++ b/1-fizzbuzz/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>fizzbuzz</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/10-tennis/pom.xml
+++ b/10-tennis/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>tennis</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/11-gilded-rose/pom.xml
+++ b/11-gilded-rose/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>gilded-rose</artifactId>
@@ -75,5 +74,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/12-raid/pom.xml
+++ b/12-raid/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>raid</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/13-golf/pom.xml
+++ b/13-golf/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>golf</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/14-smelly/pom.xml
+++ b/14-smelly/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>smelly</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/15-character-copier/pom.xml
+++ b/15-character-copier/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>character_copier</artifactId>
@@ -56,5 +55,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/16-esa-mars-rover/pom.xml
+++ b/16-esa-mars-rover/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>esa-mars-rover</artifactId>
@@ -56,5 +55,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/17-social-network/pom.xml
+++ b/17-social-network/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>social-network</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/18-katacombs/pom.xml
+++ b/18-katacombs/pom.xml
@@ -73,6 +73,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Explicitly setting up instrumentation for inline mocking with Mockito (Java 21+)  -->
+            <!-- Ref: https://javadoc.io/static/org.mockito/mockito-core/5.16.0/org.mockito/org/mockito/Mockito.html#0.3 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/18-katacombs/pom.xml
+++ b/18-katacombs/pom.xml
@@ -21,7 +21,7 @@
     </description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>

--- a/2-leap-year/pom.xml
+++ b/2-leap-year/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>leap-year</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/3-fibonacci/pom.xml
+++ b/3-fibonacci/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>fibonacci</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/4-stack/pom.xml
+++ b/4-stack/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>stack</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/5-roman/pom.xml
+++ b/5-roman/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>roman</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/6-primes/pom.xml
+++ b/6-primes/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>primes</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/7-tic-tac-toe/pom.xml
+++ b/7-tic-tac-toe/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>tic-tac-toe</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/8-yahtzee/pom.xml
+++ b/8-yahtzee/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>yahtzee</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/9-mars-rover/pom.xml
+++ b/9-mars-rover/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <artifactId>marsrover</artifactId>
@@ -51,5 +50,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.pedromsantos</groupId>
-        <version>1.0-0</version>
         <artifactId>java-kata</artifactId>
+        <version>1.0-0</version>
     </parent>
 
     <groupId>com.github.pedromsantos</groupId>
@@ -103,7 +102,6 @@
         </dependency>
     </dependencies>
 
-
     <build>
         <plugins>
             <plugin>
@@ -136,5 +134,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.pedromsantos</groupId>
@@ -11,6 +10,28 @@
     <packaging>pom</packaging>
 
     <name>Java Kata's</name>
+
+    <modules>
+        <module>1-fizzbuzz</module>
+        <module>2-leap-year</module>
+        <module>3-fibonacci</module>
+        <module>4-stack</module>
+        <module>5-roman</module>
+        <module>6-primes</module>
+        <module>7-tic-tac-toe</module>
+        <module>8-yahtzee</module>
+        <module>9-mars-rover</module>
+        <module>10-tennis</module>
+        <module>11-gilded-rose</module>
+        <module>12-raid</module>
+        <module>13-golf</module>
+        <module>14-smelly</module>
+        <module>15-character-copier</module>
+        <module>16-esa-mars-rover</module>
+        <module>17-social-network</module>
+        <module>18-katacombs</module>
+        <module>coverage</module>
+    </modules>
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
@@ -64,27 +85,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <modules>
-        <module>1-fizzbuzz</module>
-        <module>2-leap-year</module>
-        <module>3-fibonacci</module>
-        <module>4-stack</module>
-        <module>5-roman</module>
-        <module>6-primes</module>
-        <module>7-tic-tac-toe</module>
-        <module>8-yahtzee</module>
-        <module>9-mars-rover</module>
-        <module>10-tennis</module>
-        <module>11-gilded-rose</module>
-        <module>12-raid</module>
-        <module>13-golf</module>
-        <module>14-smelly</module>
-        <module>15-character-copier</module>
-        <module>16-esa-mars-rover</module>
-        <module>17-social-network</module>
-        <module>18-katacombs</module>
-        <module>coverage</module>
-    </modules>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <assertj-core.version>3.27.3</assertj-core.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-0</version>
     <packaging>pom</packaging>
 
-    <name>Java Kata's</name>
+    <name>Java Kata</name>
 
     <modules>
         <module>1-fizzbuzz</module>


### PR DESCRIPTION
Sets Java 21 target throughout.

Additionally:
* Explicitly sets up instrumentation for inline mocking with Mockito in the `katacombs` project [due to Java 21+ changes](https://javadoc.io/static/org.mockito/mockito-core/5.16.0/org.mockito/org/mockito/Mockito.html#0.3)
* Triggers GitHub action on push to **any** branch, so that forks build their branches
* Small reformattings to POMs to conform to the [POM Code Convention](https://maven.apache.org/developers/conventions/code.html#POM_Code_Convention)
* Small typo fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a streamlined multi-module structure with an updated project name.
  - Upgraded Java compatibility from version 17 to 21, enabling modern language features and improved testing.

- **Chores**
  - Adjusted CI build triggers to run on pull requests rather than on direct pushes.
  - Enhanced configuration security and clarity by enforcing secure (HTTPS) references and consolidating formatting.
  - Streamlined compiler settings by removing redundant properties and adding supportive plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->